### PR TITLE
Call `useProxy` even if global one is not configured

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -144,9 +144,7 @@ class PuppeteerPageProxyPlugin extends PuppeteerExtraPlugin {
             return page.setRequestInterception(true);
         };
 
-        if (this.proxyUrl) {
-            await page.useProxy();
-        }
+        await page.useProxy();
     }
 }
 


### PR DESCRIPTION
This PR addresses an issue where the proxy was not being set if the proxy URL was not configured globally inside the `PageProxyPlugin` function.

```ts
puppeteer.use(PageProxyPlugin());
```

```ts
const task = async ({ page, data: url }: { page: Page; data: string }) => {
    const proxyUrl = getProxyUrl();
    await page.useProxy(proxyUrl);

    const response = await page.goto(url);
    const ip = await response.text();

    console.log(ip);
};
```

Previously, the `useProxy` method did not work with this configuration (example above) and I was required to add a global configuration for the proxy.